### PR TITLE
IOS POI 搜索结果加入 城市 省份等信息

### DIFF
--- a/ios/RCTAMap/RCTAMap/RCTAMapManager.m
+++ b/ios/RCTAMap/RCTAMap/RCTAMapManager.m
@@ -642,6 +642,11 @@ RCT_EXPORT_METHOD(searchPoiByCenterCoordinate:(NSDictionary *)params)
                                     @"address": obj.address,
                                     @"tel": obj.tel,
                                     @"distance": @(obj.distance)
+                                    @"cityName": obj.city,
+                                    @"provinceName": obj.province,
+                                    @"cityCode": obj.citycode,
+                                    @"provinceCode": obj.pcode,
+                                    @"adCode": obj.adcode
                                     }];
             
         }];


### PR DESCRIPTION
感谢这里[a9def6ff5145b46bf591d98494dacdf9b9c8113e](https://github.com/react-native-component/react-native-smart-amap/commit/a9def6ff5145b46bf591d98494dacdf9b9c8113e)在安卓的搜索结果中加入了城市，省份等信息。但是IOS中没有加入，所以我顺便加一下。
顺便需要注意的是如果需要IOS返回城市和省份的信息在搜索的时候需要加入参数:
`requireExtension: true`